### PR TITLE
Add git pull into the scrape workfow

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -45,5 +45,6 @@ jobs:
         git config user.email "actions@users.noreply.github.com"
         git add -A
         timestamp=$(date -u)
+        git pull
         git commit -m "Regenerate battleground-state-changes.txt/html" || exit 0
         git push


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple changes. Just leave a
review and comment describing what you have tested in the relevant PR.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/alex/nyt-2020-election-scraper/pulls
-->

###### Motivation

I've seen a few runs of the scraper that have failed ([example](https://github.com/alex/nyt-2020-election-scraper/actions/runs/350488863)). This has happened when a PR is merged and master is moved forward between the checkout and git push steps which can be tens of seconds. Each time this happens, the results are delayed until what looks like manual reruns by Alex.

I couldn't see this in the issues list, open or closed.

###### Changes

Adding a call to git pull before committing the changes should fast-forward the branch before trying to push back to origin.

I'm not really familiar enough with github actions to know that this will work straight away but I presume if a bare `git push` works then a pull would as well.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Ensured that you have [rebased your branch](https://stackoverflow.com/a/7244456) with this repo's latest master branch.
- [x] Ensured that relevant issues are linked, if this PR resolves any outstanding.
- [x] Added a screenshot for all UI changes (you can drag the file into this edit box and it will be uploaded).
- [x] Ensured that changes to auto-generated files have not been committed; in particular, `*.html`, `*.csv`, `*.xml` and `*.json` files.
